### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Proof-of-concept Prometheus MCP server.
 
+<a href="https://glama.ai/mcp/servers/@etruong42/prometheus-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@etruong42/prometheus-mcp/badge" alt="Prometheus MCP server" />
+</a>
+
 ## Prerequisites
 
 Install `uv`: <https://docs.astral.sh/uv/getting-started/installation/>


### PR DESCRIPTION
This PR adds a badge for the [Prometheus MCP](https://glama.ai/mcp/servers/@etruong42/prometheus-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@etruong42/prometheus-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@etruong42/prometheus-mcp/badge" alt="Prometheus MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.